### PR TITLE
Add run alias for open command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ with CI/CD pipelines.
 | Name                           | Description                                                                 |
 |--------------------------------|-----------------------------------------------------------------------------|
 | `open [path]`                  | Opens the Unity editor by searching for a project within path.              |
+| `run [path]`                   | Alias for `open`, useful for headless/batchmode scripts.                    |
 | `open`                         | Shows a selection prompt of recent or favorite projects from the Unity Hub. |
 | `install [version]`            | Installs the Editor by version, fetching the revision, if necessary.        |
 | `install-missing`              | Installs all Unity versions used by projects but not installed.             |
@@ -249,6 +250,13 @@ Forward additional arguments to Unity Hub/Editor by separating them with a `--`:
 
 ```shell
 ucll open path/to/project -- -batchmode -quit
+```
+
+For build pipelines or other headless invocations, `run` is an alias for
+`open` with the same options and forwarded Unity arguments:
+
+```shell
+ucll run path/to/project -- -batchmode -quit
 ```
 
 ```shell

--- a/src/ucll.tests/ProgramTests.cs
+++ b/src/ucll.tests/ProgramTests.cs
@@ -15,6 +15,33 @@ public class ProgramTests
 		Assert.Equal(expectedVersion, result.Output);
 	}
 
+	[Fact]
+	public void RunAliasIsListedInHelp()
+	{
+		var app = new CommandAppTester();
+		app.Configure(AppConfiguration.Build);
+
+		var result = app.Run("--help");
+
+		Assert.Equal(0, result.ExitCode);
+		Assert.Contains("run", result.Output);
+		Assert.Contains("Open Unity Editor", result.Output);
+	}
+
+	[Fact]
+	public void RunAliasUsesOpenCommandOptions()
+	{
+		var app = new CommandAppTester();
+		app.Configure(AppConfiguration.Build);
+
+		var result = app.Run("run", "--help");
+
+		Assert.Equal(0, result.ExitCode);
+		Assert.Contains("--code-editor", result.Output);
+		Assert.Contains("--only-code-editor", result.Output);
+		Assert.Contains("--no-hub-args", result.Output);
+	}
+
 	private static string FindProjectVersion(string projectFile)
 	{
 		string projectContent = File.ReadAllText(projectFile);

--- a/src/ucll/AppConfiguration.cs
+++ b/src/ucll/AppConfiguration.cs
@@ -16,6 +16,7 @@ internal static class AppConfiguration
 		config.AddExample("open", "searchPath", "--code-editor");
 		config.AddExample("open", "searchPath", "--only-code-editor");
 		config.AddExample("open", "searchPath", "--", "-batchmode", "-quit");
+		config.AddExample("run", "searchPath", "--", "-batchmode", "-quit");
 
 		config.AddCommand<OpenCommand>("open")
 			.WithDescription("Open Unity Editor for a project search path or via recent projects prompt")
@@ -27,6 +28,17 @@ internal static class AppConfiguration
 			.WithExample("open", "searchPath", "--code-editor")
 			.WithExample("open", "searchPath", "--only-code-editor")
 			.WithExample("open", "searchPath", "--", "-batchmode", "-quit");
+
+		config.AddCommand<OpenCommand>("run")
+			.WithDescription("Run Unity Editor for a project search path or via recent projects prompt")
+			.WithExample("run")
+			.WithExample("run", "--favorite")
+			.WithExample("run", ".")
+			.WithExample("run", "searchPath", "--no-hub-args", "--", "-batchmode", "-quit")
+			.WithExample("run", "searchPath", "--no-hub-args")
+			.WithExample("run", "searchPath", "--code-editor")
+			.WithExample("run", "searchPath", "--only-code-editor")
+			.WithExample("run", "searchPath", "--", "-batchmode", "-quit");
 
 		config.AddCommand<CreateCommand>("create")
 			.WithDescription("Create a new Unity project")

--- a/src/ucll/Commands/Completion/CompletionCommand.cs
+++ b/src/ucll/Commands/Completion/CompletionCommand.cs
@@ -21,6 +21,7 @@ internal class CompletionCommand : BaseCommand<CompletionSettings>
 		           local -a commands
 		           commands=(
 		               'open:Open Unity Editor for a project search path or via recent projects prompt'
+		               'run:Run Unity Editor for a project search path or via recent projects prompt'
 		               'create:Create a new Unity project'
 		               'project-path:Get Unity project root directory from search path or via recent projects prompt'
 		               'editor-revision:Get revision for Unity version'
@@ -47,7 +48,7 @@ internal class CompletionCommand : BaseCommand<CompletionSettings>
 		                   ;;
 		               args)
 		                   case $words[1] in
-		                       open)
+		                       open|run)
 		                           _arguments \
 		                               '(-f --favorite --favorites)'{-f,--favorite,--favorites}'[Use favorite projects only]' \
 		                               '(-c --code-editor)'{-c,--code-editor}'[Open the solution file in the default code editor]' \


### PR DESCRIPTION
Fixes #38.

## Summary
- Registers un as an alias for the existing open command so headless/batchmode scripts can use clearer wording.
- Adds the alias to zsh completion output with the same options as open.
- Documents ucll run ... -- -batchmode -quit in the README.
- Adds command-app tests covering the alias in help and the shared open-command options.

## Testing
- git diff --check
- Not run: dotnet test src/ucll.tests -v minimal because dotnet is not installed on PATH in this environment.